### PR TITLE
Update resolvers for ihaskell-display modules

### DIFF
--- a/ihaskell-display/ihaskell-aeson/stack.yaml
+++ b/ihaskell-display/ihaskell-aeson/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-6.2
+resolver: lts-8.5

--- a/ihaskell-display/ihaskell-blaze/stack.yaml
+++ b/ihaskell-display/ihaskell-blaze/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-6.2
+resolver: lts-8.5

--- a/ihaskell-display/ihaskell-charts/stack.yaml
+++ b/ihaskell-display/ihaskell-charts/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-6.2
+resolver: lts-8.5

--- a/ihaskell-display/ihaskell-diagrams/stack.yaml
+++ b/ihaskell-display/ihaskell-diagrams/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-6.2
+resolver: lts-8.5

--- a/ihaskell-display/ihaskell-gnuplot/stack.yaml
+++ b/ihaskell-display/ihaskell-gnuplot/stack.yaml
@@ -1,7 +1,7 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-6.2
+resolver: lts-8.5
 extra-deps:
 - 'gnuplot-0.5.4'
 - data-accessor-transformers-0.2.1.7

--- a/ihaskell-display/ihaskell-hatex/stack.yaml
+++ b/ihaskell-display/ihaskell-hatex/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-6.2
+resolver: lts-8.5

--- a/ihaskell-display/ihaskell-juicypixels/stack.yaml
+++ b/ihaskell-display/ihaskell-juicypixels/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-6.2
+resolver: lts-8.5

--- a/ihaskell-display/ihaskell-magic/stack.yaml
+++ b/ihaskell-display/ihaskell-magic/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-6.2
+resolver: lts-8.5

--- a/ihaskell-display/ihaskell-plot/stack.yaml
+++ b/ihaskell-display/ihaskell-plot/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-6.2
+resolver: lts-8.5

--- a/ihaskell-display/ihaskell-rlangqq/stack.yaml
+++ b/ihaskell-display/ihaskell-rlangqq/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-6.2
+resolver: lts-8.5

--- a/ihaskell-display/ihaskell-static-canvas/stack.yaml
+++ b/ihaskell-display/ihaskell-static-canvas/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-6.2
+resolver: lts-8.5

--- a/ihaskell-display/ihaskell-widgets/stack.yaml
+++ b/ihaskell-display/ihaskell-widgets/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-6.2
+resolver: lts-8.5


### PR DESCRIPTION
How was this working before?