### PR TITLE
Update aeson lower bound

### DIFF
--- a/ihaskell.cabal
+++ b/ihaskell.cabal
@@ -54,7 +54,7 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
   build-depends:
-                       aeson                >=0.7,
+                       aeson                >=1.0,
                        base                 >=4.6,
                        base64-bytestring    >=1.0,
                        bytestring           >=0.10,


### PR DESCRIPTION
Data.Aeson.Text only exists in Aeson 1.0.0.0 and above.