### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,9 @@ jobs:
           - stack-yaml: 'stack-8.4.yaml'
           - stack-yaml: 'stack-8.6.yaml'
           - stack-yaml: 'stack-8.8.yaml'
-          - stack-yaml: 'stack.yaml'
+          - stack-yaml: 'stack-8.10.yaml'
           - stack-yaml: 'stack-9.0.yaml'
-          - stack-yaml: 'stack-9.2.yaml'
+          - stack-yaml: 'stack.yaml'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,7 +53,7 @@ jobs:
           echo "GHC_VERSION should be ${STACK_GHC_VERSION}"
           exit 1
         fi
-    - uses: elgohr/Publish-Docker-Github-Action@3.04
+    - uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: gibiansky/ihaskell
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -39,19 +39,21 @@ jobs:
           - release: 'release-9.4.nix'
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v12
-    - uses: cachix/cachix-action@v10
+    - uses: cachix/install-nix-action@v19
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
+    - uses: cachix/cachix-action@v12
       with:
         name: ihaskell
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - run: |
         nix-build --keep-going \
-        -I nixpkgs=https://github.com/NixOS/nixpkgs/tarball/nixos-22.05 \
+        -I nixpkgs=https://github.com/NixOS/nixpkgs/tarball/nixos-22.11 \
         ${{ matrix.versions.release }} \
         --arg packages "haskellPackages: [ haskellPackages.ihaskell ]"
     - run: |
         nix-shell \
-        -I nixpkgs=https://github.com/NixOS/nixpkgs/tarball/nixos-22.05 \
+        -I nixpkgs=https://github.com/NixOS/nixpkgs/tarball/nixos-22.11 \
         -p jq --run \
         'test/acceptance.nbconvert.sh result/bin/jupyter nbconvert'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # should match the GHC version of the stack.yaml resolver
 # checked in CI
-ARG GHC_VERSION=8.10.7
+ARG GHC_VERSION=9.2.7
 
 FROM haskell:${GHC_VERSION} AS ihaskell_base
 
@@ -52,6 +52,7 @@ FROM ihaskell_base AS ihaskell
 RUN apt-get update && \
     apt-get install -y python3-pip && \
     rm -rf /var/lib/apt/lists/*
+RUN pip3 install -U pip
 RUN pip3 install -U jupyterlab notebook
 
 # Create runtime user

--- a/release-9.2.nix
+++ b/release-9.2.nix
@@ -1,4 +1,4 @@
-{ compiler ? "ghc922"
+{ compiler ? "ghc925"
 , nixpkgs ? import <nixpkgs> {}
 , packages ? (_: [])
 , pythonPackages ? (_: [])

--- a/stack-8.10.yaml
+++ b/stack-8.10.yaml
@@ -1,4 +1,6 @@
-resolver: nightly-2022-09-11 # GHC 9.2.4
+# the GHC version of this resolver needs to match the GHC version in Dockerfile
+resolver: lts-18.27
+allow-newer: true
 
 flags: {}
 packages:
@@ -17,6 +19,27 @@ packages:
     - ./ihaskell-display/ihaskell-plot
     # - ./ihaskell-display/ihaskell-static-canvas
     - ./ihaskell-display/ihaskell-widgets
+
+extra-deps:
+- active-0.2.0.14
+- Chart-cairo-1.9.3
+- diagrams-1.4
+- diagrams-cairo-1.4.1.1
+- diagrams-contrib-1.4.4
+- diagrams-core-1.5.0
+- diagrams-lib-1.4.4
+- diagrams-svg-1.4.3
+- cairo-0.13.8.1
+- pango-0.13.8.1
+- glib-0.13.8.1
+- gtk2hs-buildtools-0.13.8.3
+- plot-0.2.3.11
+# - static-canvas-0.2.0.3
+- statestack-0.3
+- dual-tree-0.2.2.1
+- monoid-extras-0.6
+- svg-builder-0.1.1
+- force-layout-0.4.0.6
 
 ghc-options:
   # Eventually we want "$locals": -Wall -Wpartial-fields -Werror

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,4 @@
-# the GHC version of this resolver needs to match the GHC version in Dockerfile
-resolver: lts-18.27
-allow-newer: true
+resolver: lts-20.13
 
 flags: {}
 packages:
@@ -19,27 +17,6 @@ packages:
     - ./ihaskell-display/ihaskell-plot
     # - ./ihaskell-display/ihaskell-static-canvas
     - ./ihaskell-display/ihaskell-widgets
-
-extra-deps:
-- active-0.2.0.14
-- Chart-cairo-1.9.3
-- diagrams-1.4
-- diagrams-cairo-1.4.1.1
-- diagrams-contrib-1.4.4
-- diagrams-core-1.5.0
-- diagrams-lib-1.4.4
-- diagrams-svg-1.4.3
-- cairo-0.13.8.1
-- pango-0.13.8.1
-- glib-0.13.8.1
-- gtk2hs-buildtools-0.13.8.3
-- plot-0.2.3.11
-# - static-canvas-0.2.0.3
-- statestack-0.3
-- dual-tree-0.2.2.1
-- monoid-extras-0.6
-- svg-builder-0.1.1
-- force-layout-0.4.0.6
 
 ghc-options:
   # Eventually we want "$locals": -Wall -Wpartial-fields -Werror


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore